### PR TITLE
Use travis cmake-3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
       - gfortran
       - mercurial
       - graphviz
-      - cmake
       - gnupg2
       - r-base
       - r-base-core
@@ -18,7 +17,7 @@ addons:
 env:
   matrix:
     - APP=amg
-# no tensorflow in spack    - APP=candle-benchmarks 
+    - APP=candle-benchmarks 
     - APP=comd
     - APP=laghos
     - APP=macsio

--- a/packages.yaml
+++ b/packages.yaml
@@ -5,7 +5,7 @@ packages:
   cmake:
     buildable: False
     paths:
-      cmake@2.8.12.2: /usr
+      cmake@3.9.2: /usr/local/cmake-3.9.2
   r:
     buildable: False
     paths:


### PR DESCRIPTION
Fixed build of `nut`, `kripke` and partly `clamr` (see #2)