### PR TITLE
Fixing Issue with new tzdata dependency

### DIFF
--- a/docker/Dockerfile-ubuntu
+++ b/docker/Dockerfile-ubuntu
@@ -4,6 +4,9 @@ ARG APP
 ARG DEPS
 ARG INSECURE
 
+ENV TZ=Etc/GMT
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get -q update -y
 RUN apt-get -qq install -y make cmake git g++ gfortran mercurial graphviz gnupg2 r-base r-base-core r-base-dev perl perl-base libopenmpi-dev 
 


### PR DESCRIPTION
For reasons we can investigate later the ubuntu packages now require
the tzdata package which does not appear to have a non-interactive mode.
So a workaround from stack overflow was used